### PR TITLE
Remove two methods from each generated file.

### DIFF
--- a/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -84,74 +84,74 @@ final class Parcelables {
     return null;
   }
 
-  public static CodeBlock readValue(Types types, AutoValueParcelExtension.Property property, ParameterSpec in,
+  public static CodeBlock readValue(Types types, AutoValueParcelExtension.Property property,
       FieldSpec classloader) {
     CodeBlock.Builder block = CodeBlock.builder();
 
     if (property.nullable()){
-      block.add("$N.readInt() == 0 ? ", in);
+      block.add("in.readInt() == 0 ? ");
     }
 
-    TypeElement element = (TypeElement) types.asElement(property.element.getReturnType());    
+    TypeElement element = (TypeElement) types.asElement(property.element.getReturnType());
     final TypeName type = element != null ? getParcelableType(types, element) : property.type;
     if (type.equals(STRING))
-      block.add("$N.readString()", in);
+      block.add("in.readString()");
     else if (type.equals(TypeName.BYTE))
-      block.add("$N.readByte()", in);
+      block.add("in.readByte()");
     else if (type.equals(TypeName.INT))
-      block.add("$N.readInt()", in);
+      block.add("in.readInt()");
     else if (type.equals(TypeName.SHORT))
-      block.add("(short) $N.readInt()", in);
+      block.add("(short) in.readInt()");
     else if (type.equals(TypeName.LONG))
-      block.add("$N.readLong()", in);
+      block.add("in.readLong()");
     else if (type.equals(TypeName.FLOAT))
-      block.add("$N.readFloat()", in);
+      block.add("in.readFloat()");
     else if (type.equals(TypeName.DOUBLE))
-      block.add("$N.readDouble()", in);
+      block.add("in.readDouble()");
     else if (type.equals(TypeName.BOOLEAN))
-      block.add("$N.readInt() == 1", in);
+      block.add("in.readInt() == 1");
     else if (type.equals(PARCELABLE))
-      block.add("($T) $N.readParcelable($N)", property.type, in, classloader);
+      block.add("($T) in.readParcelable($N)", property.type, classloader);
     else if (type.equals(CHARSEQUENCE))
-      block.add("($T) $N.readCharSequence()", property.type, in);
+      block.add("($T) in.readCharSequence()", property.type);
     else if (type.equals(MAP))
-      block.add("($T) $N.readHashMap($N)", property.type, in, classloader);
+      block.add("($T) in.readHashMap($N)", property.type, classloader);
     else if (type.equals(LIST))
-      block.add("($T) $N.readArrayList($N)", property.type, in, classloader);
+      block.add("($T) in.readArrayList($N)", property.type, classloader);
     else if (type.equals(BOOLEANARRAY))
-      block.add("$N.createBooleanArray()", in);
+      block.add("in.createBooleanArray()");
     else if (type.equals(BYTEARRAY))
-      block.add("$N.createByteArray()", in);
+      block.add("in.createByteArray()");
     else if (type.equals(STRINGARRAY))
-      block.add("$N.readStringArray()", in);
+      block.add("in.readStringArray()");
     else if (type.equals(CHARSEQUENCEARRAY))
-      block.add("$N.readCharSequenceArray()", in);
+      block.add("in.readCharSequenceArray()");
     else if (type.equals(IBINDER))
-      block.add("($T) $N.readStrongBinder()", property.type, in);
+      block.add("($T) in.readStrongBinder()", property.type);
     else if (type.equals(OBJECTARRAY))
-      block.add("$N.readArray($N)", in, classloader);
+      block.add("in.readArray($N)", classloader);
     else if (type.equals(INTARRAY))
-      block.add("$N.createIntArray()", in);
+      block.add("in.createIntArray()");
     else if (type.equals(LONGARRAY))
-      block.add("$N.createLongArray()", in);
+      block.add("in.createLongArray()");
     else if (type.equals(SERIALIZABLE))
-      block.add("($T) $N.readSerializable()", property.type, in);
+      block.add("($T) in.readSerializable()", property.type);
     else if (type.equals(PARCELABLEARRAY))
-      block.add("($T) $N.readParcelableArray($N)", property.type, in, classloader);
+      block.add("($T) in.readParcelableArray($N)", property.type, classloader);
     else if (type.equals(SPARSEARRAY))
-      block.add("$N.readSparseArray($N)", in, classloader);
+      block.add("in.readSparseArray($N)", classloader);
     else if (type.equals(SPARSEBOOLEANARRAY))
-      block.add("$N.readSparseBooleanArray()", in);
+      block.add("in.readSparseBooleanArray()");
     else if (type.equals(BUNDLE))
-      block.add("$N.readBundle($N)", in, classloader);
+      block.add("in.readBundle($N)", classloader);
     else if (type.equals(PERSISTABLEBUNDLE))
-      block.add("$N.readPersistableBundle($N)", in, classloader);
+      block.add("in.readPersistableBundle($N)", classloader);
     else if (type.equals(SIZE))
-      block.add("$N.readSize()", in);
+      block.add("in.readSize()");
     else if (type.equals(SIZEF))
-      block.add("$N.readSizeF()", in);
+      block.add("in.readSizeF()");
     else
-      block.add("($T) $N.readValue($N)", property.type, in, classloader);
+      block.add("($T) in.readValue($N)", property.type, classloader);
 
     if (property.nullable()){
       block.add(" : null");

--- a/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -159,12 +159,18 @@ public class AutoValueParcelExtensionTest {
         "import java.lang.String;\n" +
         "\n" +
         "final class AutoValue_Test extends $AutoValue_Test {\n" +
-        "  private static final ClassLoader CL = AutoValue_Test.class.getClassLoader();\n" +
+        "  static final ClassLoader CL = AutoValue_Test.class.getClassLoader();\n" +
         "\n" +
         "  public static final Parcelable.Creator<AutoValue_Test> CREATOR = new android.os.Parcelable.Creator<AutoValue_Test>() {\n" +
+        "\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Test createFromParcel(android.os.Parcel in) {\n" +
-        "      return new AutoValue_Test(in);\n" +
+        "      return new AutoValue_Test(\n" +
+        "          in.readInt(),\n" +
+        "          in.readInt() == 0 ? (java.lang.Double) in.readSerializable() : null,\n" +
+        "          in.readString(),\n" +
+        "          in.readLong()\n" +
+        "      );\n" +
         "    }\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Test[] newArray(int size) {\n" +
@@ -174,15 +180,6 @@ public class AutoValueParcelExtensionTest {
         "\n" +
         "  AutoValue_Test(int a, Double b, String c, long d) {\n" +
         "    super(a, b, c, d);\n" +
-        "  }\n" +
-        "\n" +
-        "  private AutoValue_Test(Parcel in) {\n" +
-        "    super(\n" +
-        "      in.readInt(),\n" +
-        "      in.readInt() == 0 ? (Double) in.readSerializable() : null,\n" +
-        "      in.readString(),\n" +
-        "      in.readLong()\n" +
-        "    );\n" +
         "  }\n" +
         "\n" +
         "  @Override\n" +
@@ -272,12 +269,15 @@ public class AutoValueParcelExtensionTest {
         "import java.util.List;\n" +
         "\n" +
         "final class AutoValue_Test extends $AutoValue_Test {\n" +
-        "  private static final ClassLoader CL = AutoValue_Test.class.getClassLoader();\n" +
+        "  static final ClassLoader CL = AutoValue_Test.class.getClassLoader();\n" +
         "\n" +
         "  public static final Parcelable.Creator<AutoValue_Test> CREATOR = new android.os.Parcelable.Creator<AutoValue_Test>() {\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Test createFromParcel(android.os.Parcel in) {\n" +
-        "      return new AutoValue_Test(in);\n" +
+        "      return new AutoValue_Test(\n" +
+        "        (java.util.List<test.Parcelable1>) in.readArrayList(CL),\n" +
+        "        in.createIntArray()\n" +
+        "      );\n" +
         "    }\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Test[] newArray(int size) {\n" +
@@ -287,13 +287,6 @@ public class AutoValueParcelExtensionTest {
         "\n" +
         "  AutoValue_Test(List<Parcelable1> a, int[] b) {\n" +
         "    super(a, b);\n" +
-        "  }\n" +
-        "\n" +
-        "  private AutoValue_Test(Parcel in) {\n" +
-        "    super(\n" +
-        "      (List<Parcelable1>) in.readArrayList(CL),\n" +
-        "      in.createIntArray()\n" +
-        "    );\n" +
         "  }\n" +
         "\n" +
         "  @Override\n" +
@@ -399,12 +392,39 @@ public class AutoValueParcelExtensionTest {
         "import java.util.Map;\n" +
         "\n" +
         "final class AutoValue_Foo extends $AutoValue_Foo {\n" +
-        "  private static final ClassLoader CL = AutoValue_Foo.class.getClassLoader();\n" +
+        "  static final ClassLoader CL = AutoValue_Foo.class.getClassLoader();\n" +
         "\n" +
         "  public static final Parcelable.Creator<AutoValue_Foo> CREATOR = new android.os.Parcelable.Creator<AutoValue_Foo>() {\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Foo createFromParcel(android.os.Parcel in) {\n" +
-        "      return new AutoValue_Foo(in);\n" +
+        "      return new AutoValue_Foo(\n" +
+        "        in.readInt() == 0 ? in.readString() : null,\n" +
+        "        in.readByte(),\n" +
+        "        in.readInt(),\n" +
+        "        (short) in.readInt(),\n" +
+        "        in.readLong(),\n" +
+        "        in.readFloat(),\n" +
+        "        in.readDouble(),\n" +
+        "        in.readInt() == 1,\n" +
+        "        (android.os.Parcelable) in.readParcelable(CL),\n" +
+        "        (java.lang.CharSequence) in.readCharSequence(),\n" +
+        "        (java.util.Map<java.lang.String, java.lang.String>) in.readHashMap(CL),\n" +
+        "        (java.util.List<java.lang.String>) in.readArrayList(CL),\n" +
+        "        in.createBooleanArray(),\n" +
+        "        in.createByteArray(),\n" +
+        "        in.createIntArray(),\n" +
+        "        in.createLongArray(),\n" +
+        "        (java.io.Serializable) in.readSerializable(),\n" +
+        "        in.readSparseArray(CL),\n" +
+        "        in.readSparseBooleanArray(),\n" +
+        "        in.readBundle(CL),\n" +
+        "        in.readPersistableBundle(CL),\n" +
+        "        in.readSize(),\n" +
+        "        in.readSizeF(),\n" +
+        "        in.readInt() == 0 ? (test.Parcelable1) in.readParcelable(CL) : null,\n" +
+        "        (test.FooBinder) in.readStrongBinder(),\n" +
+        "        in.readInt() == 0 ? (java.lang.Boolean) in.readSerializable() : null\n" +
+        "      );\n" +
         "    }\n" +
         "    @java.lang.Override\n" +
         "    public AutoValue_Foo[] newArray(int size) {\n" +
@@ -415,36 +435,6 @@ public class AutoValueParcelExtensionTest {
         "  AutoValue_Foo(String a, byte b, int c, short d, long e, float f, double g, boolean h, Parcelable i, CharSequence j, Map<String, String> k, List<String> l, boolean[] m, byte[] n, int[] s, long[] t, Serializable u, SparseArray w, SparseBooleanArray x, Bundle y, PersistableBundle z, Size aa, SizeF ab, Parcelable1 ad, FooBinder ae, Boolean af) {\n" +
         "    super(a, b, c, d, e, f, g, h, i, j, k, l, m, n, s, t, u, w, x, y, z, aa, ab, ad, ae, af);\n" +
         "  }\n" +
-        "\n" +
-        "  private AutoValue_Foo(Parcel in) {\n" +
-        "    super(\n" +
-        "      in.readInt() == 0 ? in.readString() : null,\n" +
-        "      in.readByte(),\n" +
-        "      in.readInt(),\n" +
-        "      (short) in.readInt(),\n" +
-        "      in.readLong(),\n" +
-        "      in.readFloat(),\n" +
-        "      in.readDouble(),\n" +
-        "      in.readInt() == 1,\n" +
-        "      (Parcelable) in.readParcelable(CL),\n" +
-        "      (CharSequence) in.readCharSequence(),\n" +
-        "      (Map<String, String>) in.readHashMap(CL),\n" +
-        "      (List<String>) in.readArrayList(CL),\n" +
-        "      in.createBooleanArray(),\n" +
-        "      in.createByteArray(),\n" +
-        "      in.createIntArray(),\n" +
-        "      in.createLongArray(),\n" +
-        "      (Serializable) in.readSerializable(),\n" +
-        "      in.readSparseArray(CL),\n" +
-        "      in.readSparseBooleanArray(),\n" +
-        "      in.readBundle(CL),\n" +
-        "      in.readPersistableBundle(CL),\n" +
-        "      in.readSize(),\n" +
-        "      in.readSizeF(),\n" +
-        "      in.readInt() == 0 ? (Parcelable1) in.readParcelable(CL) : null,\n" +
-        "      (FooBinder) in.readStrongBinder(),\n" +
-        "      in.readInt() == 0 ? (Boolean) in.readSerializable() : null\n" +
-        "    );}\n" +
         "\n" +
         "  @Override\n" +
         "  public void writeToParcel(Parcel dest, int flags) {\n" +


### PR DESCRIPTION
Removes:
* Secondary private constructor which took the Parcel and pulled out fields.
* Synthetic package-scoped constructor generated by javac for the CREATOR class to call the private constructor.

This removes 206 method references from from our app.