### PR TITLE
Adds support for Parcelable interface inheritance.

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -68,9 +68,9 @@ final class Parcelables {
 
       // then check if it implements valid interfaces
       for (TypeMirror iface : type.getInterfaces()) {
-        TypeName ifaceName = TypeName.get(iface);
-        if (VALID_TYPES.contains(ifaceName)) {
-          return ifaceName;
+        TypeName inherited = getParcelableType(types, (TypeElement) types.asElement(iface));
+        if (inherited != null) {
+          return inherited;
         }
       }
 


### PR DESCRIPTION
Fixes issue causing Parcelable types whose Parcelable interface is more than one interface removed to be marked non-parcelable. Fixes #37