### PR TITLE
Omit writeToParcel and CREATOR when already defined.

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -144,9 +144,8 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
   }
 
   private static boolean needsWriteToParcel(Context context) {
-    ProcessingEnvironment processingEnv = context.processingEnvironment();
-    TypeMirror parcel = processingEnv.getElementUtils().getTypeElement("android.os.Parcel").asType();
     ProcessingEnvironment env = context.processingEnvironment();
+    TypeMirror parcel = env.getElementUtils().getTypeElement("android.os.Parcel").asType();
     for (ExecutableElement element : MoreElements.getLocalAndInheritedMethods(
             context.autoValueClass(), env.getElementUtils())) {
       if (element.getSimpleName().contentEquals("writeToParcel")
@@ -154,7 +153,7 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
               && !element.getModifiers().contains(Modifier.ABSTRACT)) {
         List<? extends VariableElement> parameters = element.getParameters();
         if (parameters.size() == 2
-                && processingEnv.getTypeUtils().isSameType(parcel, parameters.get(0).asType())
+                && env.getTypeUtils().isSameType(parcel, parameters.get(0).asType())
                 && MoreTypes.isTypeOf(int.class, parameters.get(1).asType())) {
           return false;
         }
@@ -164,11 +163,11 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
   }
 
   private static boolean needsCreator(Context context) {
-    ProcessingEnvironment processingEnv = context.processingEnvironment();
-    Types typeUtils = processingEnv.getTypeUtils();
-    Elements elementUtils = processingEnv.getElementUtils();
+    ProcessingEnvironment env = context.processingEnvironment();
+    Types typeUtils = env.getTypeUtils();
+    Elements elementUtils = env.getElementUtils();
     TypeMirror creatorType = typeUtils.erasure(elementUtils.getTypeElement("android.os.Parcelable.Creator").asType());
-    List<? extends Element> members = processingEnv.getElementUtils().getAllMembers(context.autoValueClass());
+    List<? extends Element> members = env.getElementUtils().getAllMembers(context.autoValueClass());
     for (VariableElement field : ElementFilter.fieldsIn(members)) {
       if (field.asType() instanceof DeclaredType) {
         List<? extends TypeMirror> typeArguments = ((DeclaredType) field.asType()).getTypeArguments();

--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -28,14 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.ArrayType;
-import javax.lang.model.type.MirroredTypeException;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
@@ -85,8 +81,12 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
     TypeMirror parcelable = context.processingEnvironment().getElementUtils()
         .getTypeElement("android.os.Parcelable").asType();
     TypeMirror autoValueClass = context.autoValueClass().asType();
-    return TypeSimplifier.isClassOfType(context.processingEnvironment().getTypeUtils(), parcelable,
+    boolean isParcelable = TypeSimplifier.isClassOfType(context.processingEnvironment().getTypeUtils(), parcelable,
         autoValueClass);
+    boolean needsImplementation = needsContentDescriptor(context)
+            || needsWriteToParcel(context)
+            || needsCreator(context);
+    return isParcelable && needsImplementation;
   }
 
   @Override
@@ -111,9 +111,15 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
     TypeSpec.Builder subclass = TypeSpec.classBuilder(className)
         .addModifiers(Modifier.FINAL)
         .superclass(TypeVariableName.get(classToExtend))
-        .addMethod(generateConstructor(properties))
-        .addField(generateCreator(env, properties, type))
-        .addMethod(generateWriteToParcel(env, properties));
+        .addMethod(generateConstructor(properties));
+
+    if (needsCreator(context)) {
+      subclass.addField(generateCreator(env, properties, type));
+    }
+
+    if (needsWriteToParcel(context)) {
+      subclass.addMethod(generateWriteToParcel(env, properties));
+    }
 
     if (needsContentDescriptor(context)) {
       subclass.addMethod(generateDescribeContents());
@@ -132,6 +138,49 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
           && element.getParameters().isEmpty()
           && !element.getModifiers().contains(Modifier.ABSTRACT)) {
         return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean needsWriteToParcel(Context context) {
+    ProcessingEnvironment processingEnv = context.processingEnvironment();
+    TypeMirror parcel = processingEnv.getElementUtils().getTypeElement("android.os.Parcel").asType();
+    ProcessingEnvironment env = context.processingEnvironment();
+    for (ExecutableElement element : MoreElements.getLocalAndInheritedMethods(
+            context.autoValueClass(), env.getElementUtils())) {
+      if (element.getSimpleName().contentEquals("writeToParcel")
+              && MoreTypes.isTypeOf(void.class, element.getReturnType())
+              && !element.getModifiers().contains(Modifier.ABSTRACT)) {
+        List<? extends VariableElement> parameters = element.getParameters();
+        if (parameters.size() == 2
+                && processingEnv.getTypeUtils().isSameType(parcel, parameters.get(0).asType())
+                && MoreTypes.isTypeOf(int.class, parameters.get(1).asType())) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static boolean needsCreator(Context context) {
+    ProcessingEnvironment processingEnv = context.processingEnvironment();
+    Types typeUtils = processingEnv.getTypeUtils();
+    Elements elementUtils = processingEnv.getElementUtils();
+    TypeMirror creatorType = typeUtils.erasure(elementUtils.getTypeElement("android.os.Parcelable.Creator").asType());
+    List<? extends Element> members = processingEnv.getElementUtils().getAllMembers(context.autoValueClass());
+    for (VariableElement field : ElementFilter.fieldsIn(members)) {
+      if (field.asType() instanceof DeclaredType) {
+        List<? extends TypeMirror> typeArguments = ((DeclaredType) field.asType()).getTypeArguments();
+        if (typeArguments.size() == 1
+                && field.getSimpleName().contentEquals("CREATOR")
+                && typeUtils.isSameType(creatorType, typeUtils.erasure(field.asType()))
+                && typeUtils.isAssignable(context.autoValueClass().asType(), typeArguments.get(0))
+                && field.getModifiers().contains(Modifier.STATIC)
+                && field.getModifiers().contains(Modifier.PUBLIC)
+                && field.getModifiers().contains(Modifier.FINAL)) {
+          return false;
+        }
       }
     }
     return true;

--- a/auto-value-parcel/src/test/java/android/os/Parcelable.java
+++ b/auto-value-parcel/src/test/java/android/os/Parcelable.java
@@ -1,6 +1,11 @@
 package android.os;
 
 public interface Parcelable {
+  public interface Creator<T> {
+    T createFromParcel(Parcel var1);
+
+    T[] newArray(int var1);
+  }
 
   int describeContents();
   void writeToParcel(Object dest, int flags);

--- a/auto-value-parcel/src/test/java/android/os/Parcelable.java
+++ b/auto-value-parcel/src/test/java/android/os/Parcelable.java
@@ -8,6 +8,6 @@ public interface Parcelable {
   }
 
   int describeContents();
-  void writeToParcel(Object dest, int flags);
+  void writeToParcel(Parcel dest, int flags);
 
 }

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -470,30 +470,19 @@ public class AutoValueParcelExtensionTest {
   }
 
   @Test public void writeToParcelOmittedWhenAlreadyDefined() {
-    JavaFileObject notMatching = JavaFileObjects.forSourceString("test.No", ""
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
             + "package test;\n"
             + "import android.os.Parcel;\n"
             + "import android.os.Parcelable;\n"
             + "import com.google.auto.value.AutoValue;\n"
-            + "@AutoValue public abstract class No implements Parcelable {\n"
-            + "  public abstract String name();\n"
-            + "  @Override public abstract void writeToParcel(Parcel parcel, int flags);\n"
-            + "  public void writeToParcel(Parcel parcel) {\n"
-            + "  }\n"
-            + "}");
-    JavaFileObject matching = JavaFileObjects.forSourceString("test.Yes", ""
-            + "package test;\n"
-            + "import android.os.Parcel;\n"
-            + "import android.os.Parcelable;\n"
-            + "import com.google.auto.value.AutoValue;\n"
-            + "@AutoValue public abstract class Yes implements Parcelable {\n"
+            + "@AutoValue public abstract class Test implements Parcelable {\n"
             + "  public abstract String name();\n"
             + "  public void writeToParcel(Parcel parcel, int flags) {\n"
             + "  }\n"
             + "}"
     );
 
-    JavaFileObject expectedNotMatching = JavaFileObjects.forSourceString("test/AutoValue_No", ""
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
             + "package test;\n" +
             "\n" +
             "import android.os.Parcel;\n" +
@@ -501,58 +490,21 @@ public class AutoValueParcelExtensionTest {
             "import java.lang.Override;\n" +
             "import java.lang.String;\n" +
             "\n" +
-            "final class AutoValue_No extends $AutoValue_No {\n" +
-            "  public static final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n" +
+            "final class AutoValue_Test extends $AutoValue_Test {\n" +
+            "  public static final Parcelable.Creator<AutoValue_Test> CREATOR = new Parcelable.Creator<AutoValue_Test>() {\n" +
             "    @Override\n" +
-            "    public AutoValue_No createFromParcel(Parcel in) {\n" +
-            "      return new AutoValue_No(\n" +
+            "    public AutoValue_Test createFromParcel(Parcel in) {\n" +
+            "      return new AutoValue_Test(\n" +
             "        in.readString()\n" +
             "      );\n" +
             "    }\n" +
             "    @Override\n" +
-            "    public AutoValue_No[] newArray(int size) {\n" +
-            "      return new AutoValue_No[size];\n" +
+            "    public AutoValue_Test[] newArray(int size) {\n" +
+            "      return new AutoValue_Test[size];\n" +
             "    }\n" +
             "  };\n" +
             "\n" +
-            "  AutoValue_No(String name) {\n" +
-            "    super(name);\n" +
-            "  }\n" +
-            "\n" +
-            "  @Override\n" +
-            "  public void writeToParcel(Parcel dest, int flags) {\n" +
-            "    dest.writeString(name());\n" +
-            "  }\n" +
-            "\n" +
-            "  @Override\n" +
-            "  public int describeContents() {\n" +
-            "    return 0;\n" +
-            "  }\n" +
-            "}");
-
-    JavaFileObject expectedMatching = JavaFileObjects.forSourceString("test/AutoValue_Yes", ""
-            + "package test;\n" +
-            "\n" +
-            "import android.os.Parcel;\n" +
-            "import android.os.Parcelable;\n" +
-            "import java.lang.Override;\n" +
-            "import java.lang.String;\n" +
-            "\n" +
-            "final class AutoValue_Yes extends $AutoValue_Yes {\n" +
-            "  public static final Parcelable.Creator<AutoValue_Yes> CREATOR = new Parcelable.Creator<AutoValue_Yes>() {\n" +
-            "    @Override\n" +
-            "    public AutoValue_Yes createFromParcel(Parcel in) {\n" +
-            "      return new AutoValue_Yes(\n" +
-            "        in.readString()\n" +
-            "      );\n" +
-            "    }\n" +
-            "    @Override\n" +
-            "    public AutoValue_Yes[] newArray(int size) {\n" +
-            "      return new AutoValue_Yes[size];\n" +
-            "    }\n" +
-            "  };\n" +
-            "\n" +
-            "  AutoValue_Yes(String name) {\n" +
+            "  AutoValue_Test(String name) {\n" +
             "    super(name);\n" +
             "  }\n" +
             "\n" +
@@ -563,102 +515,43 @@ public class AutoValueParcelExtensionTest {
             "}");
 
     assertAbout(javaSources())
-            .that(Arrays.asList(parcel, parcelable, notMatching, matching))
+            .that(Arrays.asList(parcel, parcelable, source))
             .processedWith(new AutoValueProcessor())
             .compilesWithoutError()
             .and()
-            .generatesSources(expectedNotMatching, expectedMatching);
+            .generatesSources(expected);
   }
 
   @Test public void creatorOmittedWhenAlreadyDefined() {
-    JavaFileObject notMatching = JavaFileObjects.forSourceString("test.No", ""
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
             + "package test;\n"
             + "import android.os.Parcel;\n"
             + "import android.os.Parcelable;\n"
             + "import com.google.auto.value.AutoValue;\n"
-            + "@AutoValue public abstract class No implements Parcelable {\n"
+            + "@AutoValue public abstract class Test implements Parcelable {\n"
             + "  public abstract String name();\n"
-            + "  public final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n"
+            + "  public static final Parcelable.Creator<Test> CREATOR = new Parcelable.Creator<Test>() {\n"
             + "    @Override\n"
-            + "    public AutoValue_No createFromParcel(Parcel in) {\n"
-            + "      return new AutoValue_No(\n"
-            + "        in.readString()\n"
-            + "      );\n"
+            + "    public Test createFromParcel(Parcel in) {\n"
+            + "      return null;\n"
             + "    }\n"
             + "    @Override\n"
-            + "    public AutoValue_No[] newArray(int size) {\n"
-            + "      return new AutoValue_No[size];\n"
-            + "    }\n"
-            + "  };\n"
-            + "}");
-    JavaFileObject matching = JavaFileObjects.forSourceString("test.Yes", ""
-            + "package test;\n"
-            + "import android.os.Parcel;\n"
-            + "import android.os.Parcelable;\n"
-            + "import com.google.auto.value.AutoValue;\n"
-            + "@AutoValue public abstract class Yes implements Parcelable {\n"
-            + "  public abstract String name();\n"
-            + "  public static final Parcelable.Creator<AutoValue_Yes> CREATOR = new Parcelable.Creator<AutoValue_Yes>() {\n"
-            + "    @Override\n"
-            + "    public AutoValue_Yes createFromParcel(Parcel in) {\n"
-            + "      return new AutoValue_Yes(\n"
-            + "        in.readString()\n"
-            + "      );\n"
-            + "    }\n"
-            + "    @Override\n"
-            + "    public AutoValue_Yes[] newArray(int size) {\n"
-            + "      return new AutoValue_Yes[size];\n"
+            + "    public Test[] newArray(int size) {\n"
+            + "      return new Test[size];\n"
             + "    }\n"
             + "  };\n"
             + "}"
     );
 
-    JavaFileObject expectedNotMatching = JavaFileObjects.forSourceString("test/AutoValue_No", ""
-            + "package test;\n" +
-            "\n" +
-            "import android.os.Parcel;\n" +
-            "import android.os.Parcelable;\n" +
-            "import java.lang.Override;\n" +
-            "import java.lang.String;\n" +
-            "\n" +
-            "final class AutoValue_No extends $AutoValue_No {\n" +
-            "  public static final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n" +
-            "    @Override\n" +
-            "    public AutoValue_No createFromParcel(Parcel in) {\n" +
-            "      return new AutoValue_No(\n" +
-            "        in.readString()\n" +
-            "      );\n" +
-            "    }\n" +
-            "    @Override\n" +
-            "    public AutoValue_No[] newArray(int size) {\n" +
-            "      return new AutoValue_No[size];\n" +
-            "    }\n" +
-            "  };\n" +
-            "\n" +
-            "  AutoValue_No(String name) {\n" +
-            "    super(name);\n" +
-            "  }\n" +
-            "\n" +
-            "  @Override\n" +
-            "  public void writeToParcel(Parcel dest, int flags) {\n" +
-            "    dest.writeString(name());\n" +
-            "  }\n" +
-            "\n" +
-            "  @Override\n" +
-            "  public int describeContents() {\n" +
-            "    return 0;\n" +
-            "  }\n" +
-            "}");
-
-    JavaFileObject expectedMatching = JavaFileObjects.forSourceString("test/AutoValue_Yes", ""
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
             + "package test;\n" +
             "\n" +
             "import android.os.Parcel;\n" +
             "import java.lang.Override;\n" +
             "import java.lang.String;\n" +
             "\n" +
-            "final class AutoValue_Yes extends $AutoValue_Yes {\n" +
-            "  AutoValue_Yes(String name) {\n" +
+            "final class AutoValue_Test extends $AutoValue_Test {\n" +
+            "  AutoValue_Test(String name) {\n" +
             "    super(name);\n" +
             "  }\n" +
             "\n" +
@@ -674,11 +567,11 @@ public class AutoValueParcelExtensionTest {
             "}");
 
     assertAbout(javaSources())
-            .that(Arrays.asList(parcel, parcelable, notMatching, matching))
+            .that(Arrays.asList(parcel, parcelable, source))
             .processedWith(new AutoValueProcessor())
             .compilesWithoutError()
             .and()
-            .generatesSources(expectedNotMatching, expectedMatching);
+            .generatesSources(expected);
   }
 
   @Test public void noOpWhenParcelableContractIsSatisfied() {

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -8,6 +8,7 @@ import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.CompilationRule;
 import com.google.testing.compile.JavaFileObjects;
+import com.ryanharter.auto.value.parcel.model.SampleTypeWithParcelableContractSatisfied;
 import com.ryanharter.auto.value.parcel.util.TestMessager;
 import com.ryanharter.auto.value.parcel.util.TestProcessingEnvironment;
 
@@ -32,6 +33,7 @@ import javax.tools.JavaFileObject;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class AutoValueParcelExtensionTest {
@@ -384,9 +386,9 @@ public class AutoValueParcelExtensionTest {
         + "import com.google.auto.value.AutoValue;\n"
         + "@AutoValue public abstract class Yes implements Parcelable {\n"
         + "  public abstract String name();\n"
-        + "public int describeContents() {\n"
-        + "  return 0;\n"
-        + "}\n"
+        + "  public int describeContents() {\n"
+        + "    return 0;\n"
+        + "  }\n"
         + "}"
     );
 
@@ -465,6 +467,224 @@ public class AutoValueParcelExtensionTest {
         .compilesWithoutError()
         .and()
         .generatesSources(expectedNotMatching, expectedMatching);
+  }
+
+  @Test public void writeToParcelOmittedWhenAlreadyDefined() {
+    JavaFileObject notMatching = JavaFileObjects.forSourceString("test.No", ""
+            + "package test;\n"
+            + "import android.os.Parcel;\n"
+            + "import android.os.Parcelable;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "@AutoValue public abstract class No implements Parcelable {\n"
+            + "  public abstract String name();\n"
+            + "  @Override public abstract void writeToParcel(Parcel parcel, int flags);\n"
+            + "  public void writeToParcel(Parcel parcel) {\n"
+            + "  }\n"
+            + "}");
+    JavaFileObject matching = JavaFileObjects.forSourceString("test.Yes", ""
+            + "package test;\n"
+            + "import android.os.Parcel;\n"
+            + "import android.os.Parcelable;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "@AutoValue public abstract class Yes implements Parcelable {\n"
+            + "  public abstract String name();\n"
+            + "  public void writeToParcel(Parcel parcel, int flags) {\n"
+            + "  }\n"
+            + "}"
+    );
+
+    JavaFileObject expectedNotMatching = JavaFileObjects.forSourceString("test/AutoValue_No", ""
+            + "package test;\n" +
+            "\n" +
+            "import android.os.Parcel;\n" +
+            "import android.os.Parcelable;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "\n" +
+            "final class AutoValue_No extends $AutoValue_No {\n" +
+            "  public static final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n" +
+            "    @Override\n" +
+            "    public AutoValue_No createFromParcel(Parcel in) {\n" +
+            "      return new AutoValue_No(\n" +
+            "        in.readString()\n" +
+            "      );\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public AutoValue_No[] newArray(int size) {\n" +
+            "      return new AutoValue_No[size];\n" +
+            "    }\n" +
+            "  };\n" +
+            "\n" +
+            "  AutoValue_No(String name) {\n" +
+            "    super(name);\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public void writeToParcel(Parcel dest, int flags) {\n" +
+            "    dest.writeString(name());\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public int describeContents() {\n" +
+            "    return 0;\n" +
+            "  }\n" +
+            "}");
+
+    JavaFileObject expectedMatching = JavaFileObjects.forSourceString("test/AutoValue_Yes", ""
+            + "package test;\n" +
+            "\n" +
+            "import android.os.Parcel;\n" +
+            "import android.os.Parcelable;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "\n" +
+            "final class AutoValue_Yes extends $AutoValue_Yes {\n" +
+            "  public static final Parcelable.Creator<AutoValue_Yes> CREATOR = new Parcelable.Creator<AutoValue_Yes>() {\n" +
+            "    @Override\n" +
+            "    public AutoValue_Yes createFromParcel(Parcel in) {\n" +
+            "      return new AutoValue_Yes(\n" +
+            "        in.readString()\n" +
+            "      );\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public AutoValue_Yes[] newArray(int size) {\n" +
+            "      return new AutoValue_Yes[size];\n" +
+            "    }\n" +
+            "  };\n" +
+            "\n" +
+            "  AutoValue_Yes(String name) {\n" +
+            "    super(name);\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public int describeContents() {\n" +
+            "    return 0;\n" +
+            "  }\n" +
+            "}");
+
+    assertAbout(javaSources())
+            .that(Arrays.asList(parcel, parcelable, notMatching, matching))
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .and()
+            .generatesSources(expectedNotMatching, expectedMatching);
+  }
+
+  @Test public void creatorOmittedWhenAlreadyDefined() {
+    JavaFileObject notMatching = JavaFileObjects.forSourceString("test.No", ""
+            + "package test;\n"
+            + "import android.os.Parcel;\n"
+            + "import android.os.Parcelable;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "@AutoValue public abstract class No implements Parcelable {\n"
+            + "  public abstract String name();\n"
+            + "  public final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n"
+            + "    @Override\n"
+            + "    public AutoValue_No createFromParcel(Parcel in) {\n"
+            + "      return new AutoValue_No(\n"
+            + "        in.readString()\n"
+            + "      );\n"
+            + "    }\n"
+            + "    @Override\n"
+            + "    public AutoValue_No[] newArray(int size) {\n"
+            + "      return new AutoValue_No[size];\n"
+            + "    }\n"
+            + "  };\n"
+            + "}");
+    JavaFileObject matching = JavaFileObjects.forSourceString("test.Yes", ""
+            + "package test;\n"
+            + "import android.os.Parcel;\n"
+            + "import android.os.Parcelable;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "@AutoValue public abstract class Yes implements Parcelable {\n"
+            + "  public abstract String name();\n"
+            + "  public static final Parcelable.Creator<AutoValue_Yes> CREATOR = new Parcelable.Creator<AutoValue_Yes>() {\n"
+            + "    @Override\n"
+            + "    public AutoValue_Yes createFromParcel(Parcel in) {\n"
+            + "      return new AutoValue_Yes(\n"
+            + "        in.readString()\n"
+            + "      );\n"
+            + "    }\n"
+            + "    @Override\n"
+            + "    public AutoValue_Yes[] newArray(int size) {\n"
+            + "      return new AutoValue_Yes[size];\n"
+            + "    }\n"
+            + "  };\n"
+            + "}"
+    );
+
+    JavaFileObject expectedNotMatching = JavaFileObjects.forSourceString("test/AutoValue_No", ""
+            + "package test;\n" +
+            "\n" +
+            "import android.os.Parcel;\n" +
+            "import android.os.Parcelable;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "\n" +
+            "final class AutoValue_No extends $AutoValue_No {\n" +
+            "  public static final Parcelable.Creator<AutoValue_No> CREATOR = new Parcelable.Creator<AutoValue_No>() {\n" +
+            "    @Override\n" +
+            "    public AutoValue_No createFromParcel(Parcel in) {\n" +
+            "      return new AutoValue_No(\n" +
+            "        in.readString()\n" +
+            "      );\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public AutoValue_No[] newArray(int size) {\n" +
+            "      return new AutoValue_No[size];\n" +
+            "    }\n" +
+            "  };\n" +
+            "\n" +
+            "  AutoValue_No(String name) {\n" +
+            "    super(name);\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public void writeToParcel(Parcel dest, int flags) {\n" +
+            "    dest.writeString(name());\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public int describeContents() {\n" +
+            "    return 0;\n" +
+            "  }\n" +
+            "}");
+
+    JavaFileObject expectedMatching = JavaFileObjects.forSourceString("test/AutoValue_Yes", ""
+            + "package test;\n" +
+            "\n" +
+            "import android.os.Parcel;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "\n" +
+            "final class AutoValue_Yes extends $AutoValue_Yes {\n" +
+            "  AutoValue_Yes(String name) {\n" +
+            "    super(name);\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public void writeToParcel(Parcel dest, int flags) {\n" +
+            "    dest.writeString(name());\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public int describeContents() {\n" +
+            "    return 0;\n" +
+            "  }\n" +
+            "}");
+
+    assertAbout(javaSources())
+            .that(Arrays.asList(parcel, parcelable, notMatching, matching))
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .and()
+            .generatesSources(expectedNotMatching, expectedMatching);
+  }
+
+  @Test public void noOpWhenParcelableContractIsSatisfied() {
+    TypeElement type = elements.getTypeElement(SampleTypeWithParcelableContractSatisfied.class.getCanonicalName());
+    AutoValueExtension.Context context = createContext(type);
+    assertFalse(extension.applicable(context));
   }
 
   @Test public void handlesAllParcelableTypes() {

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/model/SampleTypeWithParcelableContractSatisfied.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/model/SampleTypeWithParcelableContractSatisfied.java
@@ -1,0 +1,28 @@
+package com.ryanharter.auto.value.parcel.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public abstract class SampleTypeWithParcelableContractSatisfied implements Parcelable {
+  public static final Parcelable.Creator<SampleTypeWithParcelableContractSatisfied> CREATOR =
+      new Parcelable.Creator<SampleTypeWithParcelableContractSatisfied>() {
+        @Override
+        public SampleTypeWithParcelableContractSatisfied createFromParcel(Parcel var1) {
+          return null;
+        }
+
+        @Override
+        public SampleTypeWithParcelableContractSatisfied[] newArray(int var1) {
+          return new SampleTypeWithParcelableContractSatisfied[0];
+        }
+      };
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+}


### PR DESCRIPTION
No-op if everything is already defined.