### PR TITLE
Use createFromParcel and writeToParcel directly

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -148,7 +148,7 @@ final class Parcelables {
         block.add("in.readParcelable($T.class.getClassLoader())",
             getParcelableComponent(types, property.element.getReturnType()));
       } else {
-        block.add("($T) in.readParcelable($T.class.getClassLoader())", property.type,
+        block.add("$T.CREATOR.createFromParcel(in)",
             getParcelableComponent(types, property.element.getReturnType()));
       }
     } else if (parcelableType.equals(CHARSEQUENCE)) {
@@ -263,7 +263,7 @@ final class Parcelables {
     else if (type.equals(TypeName.BOOLEAN) || type.equals(TypeName.BOOLEAN.box()))
       block.add("$N.writeInt($N() ? 1 : 0)", out, property.methodName);
     else if (type.equals(PARCELABLE))
-      block.add("$N.writeParcelable($N(), 0)", out, property.methodName);
+      block.add("$N().writeToParcel($N, 0)", property.methodName, out);
     else if (type.equals(CHARSEQUENCE))
       block.add("$T.writeToParcel($N(), $N, 0)", TEXTUTILS, property.methodName, out);
     else if (type.equals(MAP))

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -317,6 +317,14 @@ public class AutoValueParcelExtensionTest {
         + "  }\n"
         + "  public void writeToParcel(Parcel in, int flags) {"
         + "  }\n"
+        + "  public static final Creator<Parcelable1> CREATOR = new Creator<Parcelable1>() {\n"
+        + "    public Parcelable1 createFromParcel(Parcel in) {\n"
+        + "      return new Parcelable1();\n"
+        + "    }\n"
+        + "    public Parcelable1[] newArray(int size) {\n"
+        + "      return new Parcelable1[size];\n"
+        + "    }\n"
+        + "  };"
         + "}");
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
         + "package test;\n"
@@ -545,6 +553,14 @@ public class AutoValueParcelExtensionTest {
         + "  }\n"
         + "  public void writeToParcel(Parcel in, int flags) {"
         + "  }\n"
+        + "  public static final Creator<Parcelable1> CREATOR = new Creator<Parcelable1>() {\n"
+        + "    public Parcelable1 createFromParcel(Parcel in) {\n"
+        + "      return new Parcelable1();\n"
+        + "    }\n"
+        + "    public Parcelable1[] newArray(int size) {\n"
+        + "      return new Parcelable1[size];\n"
+        + "    }\n"
+        + "  };"
         + "}");
     JavaFileObject foobinder = JavaFileObjects.forSourceString("test.FooBinder", "" +
         "package test;\n" +
@@ -670,7 +686,7 @@ public class AutoValueParcelExtensionTest {
         "        in.readPersistableBundle(PersistableBundle.class.getClassLoader()),\n" +
         "        in.readSize(),\n" +
         "        in.readSizeF(),\n" +
-        "        in.readInt() == 0 ? (Parcelable1) in.readParcelable(Parcelable1.class.getClassLoader()) : null,\n" +
+        "        in.readInt() == 0 ? Parcelable1.CREATOR.createFromParcel(in) : null,\n" +
         "        (FooBinder) in.readStrongBinder(),\n" +
         "        in.readInt() == 0 ? in.readInt() == 1 : null,\n" +
         "        (char) in.readInt(),\n" +
@@ -710,7 +726,7 @@ public class AutoValueParcelExtensionTest {
         "    dest.writeDouble(G());\n" +
         "    dest.writeInt(h() ? 1 : 0);\n" +
         "    dest.writeInt(H() ? 1 : 0);\n" +
-        "    dest.writeParcelable(i(), 0);\n" +
+        "    i().writeToParcel(dest, 0);\n" +
         "    TextUtils.writeToParcel(j(), dest, 0);\n" +
         "    dest.writeMap(k());\n" +
         "    dest.writeList(l());\n" +
@@ -729,7 +745,7 @@ public class AutoValueParcelExtensionTest {
         "      dest.writeInt(1);\n" +
         "    } else {\n" +
         "      dest.writeInt(0);\n" +
-        "      dest.writeParcelable(ad(), 0);\n" +
+        "      ad().writeToParcel(dest, 0);\n" +
         "    }\n" +
         "    dest.writeStrongBinder(ae());\n" +
         "    if (af() == null) {\n" +
@@ -1183,7 +1199,7 @@ public class AutoValueParcelExtensionTest {
         + "    @Override\n"
         + "    public AutoValue_Foo createFromParcel(Parcel in) {\n"
         + "      return new AutoValue_Foo(\n"
-        + "          (Param) in.readParcelable(Param.class.getClassLoader())\n"
+        + "          Param.CREATOR.createFromParcel(in)\n"
         + "      );\n"
         + "    }\n"
         + "    @Override\n"
@@ -1198,7 +1214,7 @@ public class AutoValueParcelExtensionTest {
         + "\n"
         + "  @Override\n"
         + "  public void writeToParcel(Parcel dest, int flags) {\n"
-        + "    dest.writeParcelable(param(), 0);\n"
+        + "    param().writeToParcel(dest, 0);\n"
         + "  }\n"
         + "\n"
         + "  @Override\n"


### PR DESCRIPTION
I'm not an AutoValue user yet, so I-Have-No-Idea-What-Im-Doing.jpeg. I'm just kicking the tires.

This change is supposed to use the write and create methods directly to avoid the needless writing and reading of the CREATOR's class name (and reflection usage) that the current methods do when we already know the name/have the instance.

This could also be extended to arrays, but I'd need to play with it some more to figure out how.