### PR TITLE
Use writeParcelable on Parcelable type

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -267,8 +267,13 @@ final class Parcelables {
       block.add("$N.writeDouble($N())", out, property.methodName);
     else if (type.equals(TypeName.BOOLEAN) || type.equals(TypeName.BOOLEAN.box()))
       block.add("$N.writeInt($N() ? 1 : 0)", out, property.methodName);
-    else if (type.equals(PARCELABLE))
-      block.add("$N().writeToParcel($N, $N)", property.methodName, out, flags);
+    else if (type.equals(PARCELABLE)) {
+      if (property.type.equals(PARCELABLE)) {
+        block.add("$N.writeParcelable($N(), $N)", out, property.methodName, flags);
+      } else {
+        block.add("$N().writeToParcel($N, $N)", property.methodName, out, flags);
+      }
+    }
     else if (type.equals(CHARSEQUENCE))
       block.add("$T.writeToParcel($N(), $N, $N)", TEXTUTILS, property.methodName, out, flags);
     else if (type.equals(MAP))

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -755,7 +755,7 @@ public class AutoValueParcelExtensionTest {
         "    dest.writeDouble(G());\n" +
         "    dest.writeInt(h() ? 1 : 0);\n" +
         "    dest.writeInt(H() ? 1 : 0);\n" +
-        "    i().writeToParcel(dest, flags);\n" +
+        "    dest.writeParcelable(i(), flags);\n" +
         "    TextUtils.writeToParcel(j(), dest, flags);\n" +
         "    dest.writeMap(k());\n" +
         "    dest.writeList(l());\n" +


### PR DESCRIPTION
This was going to break because the read was correctly using the readParcelable method.

There is a bigger problem, though. This will fix the case for when someone has a Parcelable type field. But, someone is bound to, for some reason, have a non-final Parcelable type as a field. Even if the Creator instance exists on it, it would be the wrong one (the field's type could be a subclass).

```
final class World implements Parcelable {
  final Animal;

  ...

  static abstract class Animal implements Parcelable {}

  static final class Giraffe extends Animal {
    ...
    static final CREATOR ....
  }
}
```

`World` should use readParcelable and writeParcelable there, since `Animal` doesn't have the CREATOR instance for any of the actual types like `Giraffe`. It's poor code, but it's possible code.

Should we only use the CREATOR directly when the type is declared final?