### PR TITLE
Adds better validation of maps. fixes #73

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -246,10 +246,15 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
         type = aType.getComponentType();
       }
       TypeElement element = (TypeElement) typeUtils.asElement(type);
-      if ((element == null || !Parcelables.isValidType(typeUtils, element)) &&
-          !Parcelables.isValidType(TypeName.get(type))){
-        env.getMessager().printMessage(Diagnostic.Kind.ERROR, "AutoValue property " +
-            property.methodName + " is not a supported Parcelable type.", property.element);
+      if ((element == null || !Parcelables.isValidType(typeUtils, type))
+          && !Parcelables.isValidType(TypeName.get(type))) {
+        if (element != null && Parcelables.MAP.equals(Parcelables.getParcelableType(typeUtils, element))) {
+          env.getMessager().printMessage(Diagnostic.Kind.ERROR, "Maps can only have String objects "
+              + "for keys and valid Parcelable types for values.", property.element);
+        } else {
+          env.getMessager().printMessage(Diagnostic.Kind.ERROR, "AutoValue property " +
+              property.methodName + " is not a supported Parcelable type.", property.element);
+        }
         throw new AutoValueParcelException();
       }
     }

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -1561,11 +1561,6 @@ public class AutoValueParcelExtensionTest {
     abstract ParcelableProperty parcelable();
   }
 
-  abstract class SampleTypeWithInvalidMap implements Parcelable {
-    abstract Map<String, Parcelable> valid();
-    abstract Map<Parcelable, String> invalid();
-  }
-
   abstract class ParcelableProperty implements Parcelable {}
 
   class NonSerializable {}


### PR DESCRIPTION
Parcel doesn't support all maps, but has strict requirements stating that keys must be string objects, and values must be parcelable objects.  This updates the validation to enforce that.

User's can still use a custom `TypeAdapter` to parcel arbitrary maps, but they aren't supported built in.