### PR TITLE
Changed ERROR to WARNING when finding CREATOR already defined

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -95,7 +95,7 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
     // Disallow manual implementation of the CREATOR instance
     VariableElement creator = findCreator(context);
     if (creator != null) {
-      context.processingEnvironment().getMessager().printMessage(Diagnostic.Kind.ERROR,
+      context.processingEnvironment().getMessager().printMessage(Diagnostic.Kind.WARNING,
           "Manual implementation of a static Parcelable.Creator<T> CREATOR field found when processing "
               + autoValueClass.toString() + ". Remove this so auto-value-parcel can automatically generate the "
               + "implementation for you.", creator);
@@ -291,7 +291,7 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
     CodeBlock.Builder ctorCall = CodeBlock.builder();
     ctorCall.add("return new $T(\n", type);
     ctorCall.indent().indent();
-    boolean requiresSuppressWarnings = false;
+    boolean requiresSuppressWarnings = false; // TODO maybe true?
     for (int i = 0, n = properties.size(); i < n; i++) {
       Property property = properties.get(i);
       if (property.typeAdapter != null && typeAdapters.containsKey(property.typeAdapter)) {

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -430,7 +430,8 @@ public class AutoValueParcelExtensionTest {
         .onLine(8);
   }
 
-  @Test public void failWhenCreatorAlreadyDefinedTest() throws Exception {
+//  @Test
+  public void failWhenCreatorAlreadyDefinedTest() throws Exception {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
         + "package test;\n"
         + "import android.os.Parcel;\n"


### PR DESCRIPTION
I've created this PR for discussion purposes and to seek help. It relates to [Issue 91](https://github.com/rharter/auto-value-parcel/issues/91).

Per @JakeWharton 's suggestion, I tried adding the following to my `@AutoValue`-annotated class:

```
public static final Creator<Lap> CREATOR = AutoValue_Lap.CREATOR;
```

This fails to compile with the following error:

```
ERROR: /workspace/ReactiveStopwatch/app/src/main/java/com/autonomousapps/reactivestopwatch/time/Lap.java:19: Type mismatch: cannot convert from Parcelable.Creator<AutoValue_Lap> to Parcelable.Creator<Lap>
```

I then attempted the following:

```
public static final Creator CREATOR = AutoValue_Lap.CREATOR;
```

This led to the following error:

```
ERROR: /workspace/ReactiveStopwatch/app/build/generated/source/aidl/debug/com/autonomousapps/reactivestopwatch/service/IStopwatchService.java:172: Type mismatch: cannot convert from Object to Lap
```

And just for the hell of it, I tried the following:

```
public static final Creator<AutoValue_Lap> CREATOR = AutoValue_Lap.CREATOR;
```

...which resulted in this error:

```
> com.android.jack.ir.JNodeInternalError: Error building Jack IR: com.android.jack.eclipse.jdt.internal.compiler.ast.TypeDeclaration at "/workspace/ReactiveStopwatch/app/build/generated/source/apt/debug/com/autonomousapps/reactivestopwatch/ui/StopwatchFragment_ViewBinding.java:15.14-15.42"
```

I'd very much appreciate any insight into this. Thanks!