### PR TITLE
Use Enum.valueOf instead of per-enum valueOf method.

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -265,7 +265,7 @@ final class Parcelables {
     } else if (parcelableType.equals(SIZEF)) {
       block.add("in.readSizeF()");
     } else if (parcelableType.equals(ENUM)) {
-      block.add("$T.valueOf(in.readString())", property.type);
+      block.add("$T.valueOf($T.class, in.readString())", Enum.class, property.type);
     } else {
       block.add("($T) in.readValue($T.class.getClassLoader())", property.type,
           getParcelableComponent(types, property.element.getReturnType()));

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -605,6 +605,7 @@ public class AutoValueParcelExtensionTest {
         "import java.lang.CharSequence;\n" +
         "import java.lang.Character;\n" +
         "import java.lang.Double;\n" +
+        "import java.lang.Enum;\n" +
         "import java.lang.Float;\n" +
         "import java.lang.Integer;\n" +
         "import java.lang.Long;\n" +
@@ -683,8 +684,8 @@ public class AutoValueParcelExtensionTest {
         "        in.readInt() == 0 ? (char) in.readInt() : null,\n" +
         "        in.createCharArray(),\n" +
         "        in.readInt() == 0 ? in.createCharArray() : null,\n" +
-        "        Numbers.valueOf(in.readString()),\n" +
-        "        in.readInt() == 0 ? Numbers.valueOf(in.readString()) : null,\n" +
+        "        Enum.valueOf(Numbers.class, in.readString()),\n" +
+        "        in.readInt() == 0 ? Enum.valueOf(Numbers.class, in.readString()) : null,\n" +
         "        (Numbers2) in.readParcelable(Numbers2.class.getClassLoader()),\n" +
         "        (Numbers2) in.readParcelable(Numbers2.class.getClassLoader())\n" +
         "      );\n" +


### PR DESCRIPTION
The implementation of the per-enum valueOf just calls Enum.valueOf with its own class instance anyway. Plus this saves a single method reference per-enum.