### PR TITLE
Explicitly call name() on the Enum type instead of the implementation.

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -360,7 +360,7 @@ final class Parcelables {
     else if (type.equals(SIZEF))
       block.add("$N.writeSizeF($N())", out, property.methodName);
     else if (type.equals(ENUM))
-      block.add("$N.writeString($N().name())", out, property.methodName);
+      block.add("$N.writeString((($T<?>) $N()).name())", out, Enum.class, property.methodName);
     else
       block.add("$N.writeValue($N())", out, property.methodName);
 

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -859,12 +859,12 @@ public class AutoValueParcelExtensionTest {
         "      dest.writeInt(0);\n" +
         "      dest.writeCharArray(ain());\n" +
         "    }\n" +
-        "    dest.writeString(aj().name());\n" +
+        "    dest.writeString(((Enum<?>) aj()).name());\n" +
         "    if (ajn() == null) {\n" +
         "      dest.writeInt(1);\n" +
         "    } else {\n" +
         "      dest.writeInt(0);\n" +
-        "      dest.writeString(ajn().name());\n" +
+        "      dest.writeString(((Enum<?>) ajn()).name());\n" +
         "    }\n" +
         "    dest.writeParcelable(ak(), flags);\n" +
         "    dest.writeParcelable(akn(), flags);\n" +


### PR DESCRIPTION
This saves one method reference per enum type used in an parcelable auto value type. The reason for this is that casts to supertypes are free (that is, they don't actually emit a cast). Since `name()` is a method on `Enum` and final, we can safely reference it directly using the superclass cast.