### PR TITLE
Shade autocommon and guava dependencies

### DIFF
--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -1,23 +1,29 @@
+import org.gradle.internal.jvm.Jvm
+
 plugins {
-    id 'java' 
+    id 'java-library'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    compile 'com.squareup:javapoet:1.11.0'
-    compile 'com.google.auto.value:auto-value:1.6.3rc1'
-    compile 'com.google.auto:auto-common:0.10'
-    compile 'org.apache.commons:commons-lang3:3.4'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
-    compile project(':adapter')
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'com.google.truth:truth:0.42'
-    testCompile 'org.mockito:mockito-core:2.0.26-beta'
-    testCompile 'com.google.testing.compile:compile-testing:0.15'
-    testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
+    api 'com.google.auto.value:auto-value:1.6.3rc1'
+
+    implementation 'com.squareup:javapoet:1.11.0'
+    implementation 'com.google.auto:auto-common:0.10'
+    implementation 'com.google.guava:guava:27.0-jre'
+    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation project(':adapter')
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'com.google.truth:truth:0.42'
+    testImplementation 'org.mockito:mockito-core:2.0.26-beta'
+    testImplementation 'com.google.testing.compile:compile-testing:0.15'
+    testImplementation files(Jvm.current().getToolsJar())
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'com.squareup:javapoet:1.11.0'
     implementation 'com.google.auto:auto-common:0.10'
     implementation 'com.google.guava:guava:27.0-jre'
-    implementation 'org.apache.commons:commons-lang3:3.4'
     implementation project(':adapter')
 
     testImplementation 'junit:junit:4.12'

--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -1,8 +1,36 @@
 import org.gradle.internal.jvm.Jvm
 
 plugins {
+    id 'com.github.johnrengelman.shadow' version '4.0.1'
     id 'java-library'
 }
+
+//<editor-fold desc="ShadowJar configuration">
+// disable default jar tasks
+configurations.runtimeOnly.artifacts.removeAll { it.archiveTask.is jar }
+tasks.getByName('jar').enabled = false
+// create extra configuration for shaded dependencies, so they're not included in the pom
+def shadedConfig = configurations.create('compileShaded')
+configurations.compileOnly.extendsFrom(shadedConfig)
+shadowJar {
+    minimize()
+    classifier = ''
+    configurations = [shadedConfig]
+    relocate 'com.google.auto.common', 'autovaluemoshi.shaded.com.google.auto.common'
+    relocate 'com.google.common', 'autovaluemoshi.shaded.com.google.common'
+    relocate 'com.google.thirdparty', 'autovaluemoshi.shaded.com.google.thirdparty'
+    exclude 'afu/**'
+    exclude 'org/**'
+    exclude 'com/google/errorprone/annotations/**'
+    exclude 'com/google/j2objc/annotations/**'
+    exclude 'javax/**'
+    exclude 'META-INF/maven/com.google.auto/auto-common/**'
+}
+artifacts {
+    runtime shadowJar
+    archives shadowJar
+}
+//</editor-fold>
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -13,9 +41,9 @@ dependencies {
 
     api 'com.google.auto.value:auto-value:1.6.3rc1'
 
+    compileShaded 'com.google.auto:auto-common:0.10'
+    compileShaded 'com.google.guava:guava:27.0-jre'
     implementation 'com.squareup:javapoet:1.11.0'
-    implementation 'com.google.auto:auto-common:0.10'
-    implementation 'com.google.guava:guava:27.0-jre'
     implementation project(':adapter')
 
     testImplementation 'junit:junit:4.12'

--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+    id 'java' 
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Resolves #134, also switches to `java-library` format and removes unused commons lang dependency