### PR TITLE
Bump auto value & auto service versions.

### DIFF
--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -36,10 +36,10 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
-    compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc5'
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc5'
 
-    api 'com.google.auto.value:auto-value:1.6.3rc1'
+    api 'com.google.auto.value:auto-value:1.6.3'
 
     compileShaded 'com.google.auto:auto-common:0.10'
     compileShaded 'com.google.guava:guava:27.0-jre'


### PR DESCRIPTION
## What:
1. Use stable auto-value release instead of a release candidate.
2. Use an auto-service version that has incremental annotation processor enabled. 