### PR TITLE
Fix Parcelable Creator logic (deserializer) for List and Parcelable

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -165,14 +165,21 @@ final class Parcelables {
               : property.type;
       if (!check.equals(PARCELABLE)) {
         block.add("($T) ", property.type);
+        block.add("in.readParcelable($T.class.getClassLoader())", property.type);
+      } else {
+        throw new AutoValueParcelException();
       }
-      block.add("in.readParcelable($T.class.getClassLoader())", autoValueType);
     } else if (parcelableType.equals(CHARSEQUENCE)) {
       block.add("$T.CHAR_SEQUENCE_CREATOR.createFromParcel(in)", TEXTUTILS);
     } else if (parcelableType.equals(MAP)) {
       block.add("($T) in.readHashMap($T.class.getClassLoader())", property.type, autoValueType);
     } else if (parcelableType.equals(LIST)) {
-      block.add("($T) in.readArrayList($T.class.getClassLoader())", property.type, autoValueType);
+      if (property.type instanceof ParameterizedTypeName) {
+        TypeName paramTypeName = ((ParameterizedTypeName) property.type).typeArguments.get(0);
+        block.add("($T) in.readArrayList($T.class.getClassLoader())", property.type, paramTypeName);
+      } else {
+        throw new AutoValueParcelException();
+      }
     } else if (parcelableType.equals(BOOLEANARRAY)) {
       block.add("in.createBooleanArray()");
     } else if (parcelableType.equals(BYTEARRAY)) {


### PR DESCRIPTION
After some months using this helpful AutoValue Parcel extension, I found that the current implementation is unparcelizing generic-typed fields in an inappropriate way. When a AutoValue declared class type `A` contains a field typed `List<B>`, The generated `createFromParcel` uses `readArrayList` with `ClassLoader` of type `A` -- not `B`.

I tried to fix this problem in more broad and generous way -- for example, can we fix it with the map? Can we show an informatic message to the user when the type parameter is not a concrete bound but a `extends T` or a `super T`? Can we just warn the user instead of blowing `javac` with an unhandled `AutoValueParcelException`?

But I failed because I cannot read and change the whole code, so I submit a patch currently used (by my team). Thank you.