### PR TITLE
Add SuppressWarnings for all parameterized types.

### DIFF
--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -360,7 +360,7 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
             typeAdapters.get(property.typeAdapter));
       } else {
         final TypeName typeName = Parcelables.getTypeNameFromProperty(property, typeUtils);
-        requiresSuppressWarnings |= Parcelables.isTypeRequiresSuppressWarnings(typeName);
+        requiresSuppressWarnings |= Parcelables.isTypeRequiresSuppressWarnings(property.type);
         Parcelables.readValue(ctorCall, property, typeName, autoValueType);
       }
 

--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/Parcelables.java
@@ -373,7 +373,6 @@ final class Parcelables {
   }
 
   static boolean isTypeRequiresSuppressWarnings(TypeName type) {
-    return type.equals(LIST) ||
-            type.equals(MAP);
+    return type instanceof ParameterizedTypeName;
   }
 }

--- a/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
+++ b/auto-value-parcel/src/test/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtensionTest.java
@@ -1443,6 +1443,67 @@ public class AutoValueParcelExtensionTest {
         .generatesSources(expected);
   }
 
+  @Test public void addsSuppressWarningsAnnotationWhenOptionalFieldExists() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+            + "package test;\n"
+            + "import android.os.Parcelable;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "import com.google.common.base.Optional;\n"
+            + "@AutoValue public abstract class Test implements Parcelable {\n"
+            + "public abstract Optional<String> a();\n"
+            + "}"
+    );
+
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
+            + "package test;\n" +
+            "\n" +
+            "import android.os.Parcel;\n" +
+            "import android.os.Parcelable;\n" +
+            "import com.google.common.base.Optional;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "import java.lang.SuppressWarnings;\n" +
+            "import javax.annotation.Generated;\n" +
+            "\n" +
+            "@Generated(\"com.ryanharter.auto.value.parcel.AutoValueParcelExtension\")" +
+            "final class AutoValue_Test extends $AutoValue_Test {\n" +
+            "  public static final Parcelable.Creator<AutoValue_Test> CREATOR = new Parcelable.Creator<AutoValue_Test>() {\n" +
+            "    @Override\n" +
+            "    @SuppressWarnings(\"unchecked\")\n" +
+            "    public AutoValue_Test createFromParcel(Parcel in) {\n" +
+            "      return new AutoValue_Test(\n" +
+            "          (Optional<String>) in.readSerializable()\n" +
+            "      );\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public AutoValue_Test[] newArray(int size) {\n" +
+            "      return new AutoValue_Test[size];\n" +
+            "    }\n" +
+            "  };\n" +
+            "\n" +
+            "  AutoValue_Test(Optional<String> a) {\n" +
+            "    super(a);\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public void writeToParcel(Parcel dest, int flags) {\n" +
+            "    dest.writeSerializable(a());\n" +
+            "  }\n" +
+            "\n" +
+            "  @Override\n" +
+            "  public int describeContents() {\n" +
+            "    return 0;\n" +
+            "  }\n" +
+            "}");
+
+    assertAbout(javaSources())
+            .that(Arrays.asList(parcel, parcelable, source))
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .and()
+            .generatesSources(expected);
+  }
+
   @Test public void addsSuppressWarningsAnnotationWhenListFieldExists() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
             + "package test;\n"
@@ -1503,7 +1564,6 @@ public class AutoValueParcelExtensionTest {
             .and()
             .generatesSources(expected);
   }
-
   @Test public void addsSuppressWarningsAnnotationWhenMapFieldExists() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
             + "package test;\n"
@@ -1565,7 +1625,7 @@ public class AutoValueParcelExtensionTest {
             .generatesSources(expected);
   }
 
-  @Test public void doesNotAddSuppressWarningsAnnotationWithoutMapOrList() {
+  @Test public void doesNotAddSuppressWarningsAnnotationWithoutParameterizedMembers() {
 
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
             + "package test;\n"


### PR DESCRIPTION
Issue: Currently parameterized types like Optional<String> lead to generated code of the form 
(Optional<String>) in.readSerializable()
which make an unchecked cast. This unchecked cast is a compilation error on some compilers. There is currently some logic to add @SuppressWarnings("unchecked") for lists and maps. This change modifies isTypeRequiresSuppressWarnings to return true whenever a parameterized type is given. 