### PR TITLE
Avoid calling `Element.getAnnotation(Class)`.

### DIFF
--- a/auto-value-parcel/build.gradle
+++ b/auto-value-parcel/build.gradle
@@ -36,21 +36,21 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc6'
-    compileOnly 'com.google.auto.service:auto-service:1.0-rc6'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.0'
 
-    implementation 'com.google.auto.value:auto-value:1.7'
-    implementation 'com.google.auto.value:auto-value-annotations:1.7'
-    compileShaded 'com.google.auto:auto-common:0.10'
-    compileShaded 'com.google.guava:guava:28.1-jre'
-    implementation 'com.squareup:javapoet:1.12.0'
+    implementation 'com.google.auto.value:auto-value:1.8.2'
+    implementation 'com.google.auto.value:auto-value-annotations:1.8.2'
+    compileShaded 'com.google.auto:auto-common:1.1.2'
+    compileShaded 'com.google.guava:guava:30.1.1-jre'
+    implementation 'com.squareup:javapoet:1.13.0'
     implementation project(':adapter')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'com.google.truth:truth:1.0'
-    testImplementation 'org.mockito:mockito-core:2.0.26-beta'
-    testImplementation 'com.google.auto:auto-common:0.10'
-    testImplementation 'com.google.testing.compile:compile-testing:0.18'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation 'org.mockito:mockito-core:3.12.1'
+    testImplementation 'com.google.auto:auto-common:1.1.2'
+    testImplementation 'com.google.testing.compile:compile-testing:0.19'
     testImplementation files(Jvm.current().getToolsJar())
 }
 

--- a/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
+++ b/auto-value-parcel/src/main/java/com/ryanharter/auto/value/parcel/AutoValueParcelExtension.java
@@ -1,10 +1,13 @@
 package com.ryanharter.auto.value.parcel;
 
+import com.google.auto.common.AnnotationMirrors;
+import com.google.auto.common.AnnotationValues;
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.base.CaseFormat;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -31,6 +34,7 @@ import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -58,6 +62,7 @@ import static javax.lang.model.element.Modifier.STATIC;
 public final class AutoValueParcelExtension extends AutoValueExtension {
 
   static final String FAIL_EXPLOSIVELY = "avparcel.failExplosively";
+  private static final String PARCEL_ADAPTER = "com.ryanharter.auto.value.parcel.ParcelAdapter";
 
   static final class Property {
     final String methodName;
@@ -78,13 +83,10 @@ public final class AutoValueParcelExtension extends AutoValueExtension {
       annotations = buildAnnotations(element);
       nullable = hasTypeNullableAnnotation(actualType) || nonTypeNullableAnnotation() != null;
 
-      ParcelAdapter parcelAdapter = element.getAnnotation(ParcelAdapter.class);
-      if (parcelAdapter != null) {
-        try {
-          parcelAdapter.value();
-        } catch (MirroredTypeException e) {
-          typeAdapter = e.getTypeMirror();
-        }
+      Optional<AnnotationMirror> parcelAdapter = MoreElements.getAnnotationMirror(element, PARCEL_ADAPTER);
+      if (parcelAdapter.isPresent()) {
+        AnnotationValue value = AnnotationMirrors.getAnnotationValue(parcelAdapter.get(), "value");
+        typeAdapter = AnnotationValues.getTypeMirror(value);
       }
     }
 


### PR DESCRIPTION
Using `Element.getAnnotation(String)` is generally safer.
It also avoids the ugly catch-and-extract-type code.

Also update `auto-value-parcel` dependencies.
This is needed for the `AnnotationValues.getTypeMirror` method
and I thought I might as well update the others at the same time.